### PR TITLE
Upgrade to Go 1.18

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.18
       - name: Cache Go modules
         uses: actions/cache@v2.1.7
         with:
@@ -74,7 +74,7 @@ jobs:
       matrix:
         golang:
           #- 1.13
-          - 1.14
+          - 1.18
     steps:
       - uses: actions/checkout@v3
       - name: Install Go
@@ -90,7 +90,7 @@ jobs:
     strategy:
       matrix:
         golang:
-          - 1.14
+          - 1.18
     env:
       OS: macos-latest
       GOLANG: ${{ matrix.golang }}
@@ -132,8 +132,8 @@ jobs:
         golang:
           #- 1.11
           #- 1.12
-          - 1.13
-          - 1.14
+          #- 1.13
+          - 1.18
     env:
       OS: ubuntu-latest
       GOLANG: ${{ matrix.golang }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         if: steps.semantic.outputs.new-release-published == 'true'
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.18
       -
         name: Cache Go modules
         if: steps.semantic.outputs.new-release-published == 'true'
@@ -45,12 +45,3 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Register version on pkg.go.dev
-        if: steps.semantic.outputs.new-release-published == 'true'
-        run: |
-          package=$(cat go.mod | grep ^module | awk '{print $2}')
-          version=v${{ steps.semantic.outputs.release-version }}
-          url=https://proxy.golang.org/${package}/@v/${version}.info
-          set -x +e
-          curl -i $url


### PR DESCRIPTION
This is a temporary fork to unblock devs using M1. We will submit an official PR  to the main repo as well.